### PR TITLE
Add patternlab_path twig function to es_helper module

### DIFF
--- a/Drush/EntityScaffolder/d7_1/templates/preprocess/es_helper/es_helper.module
+++ b/Drush/EntityScaffolder/d7_1/templates/preprocess/es_helper/es_helper.module
@@ -345,3 +345,20 @@ function es_helper_show_file_permissions($dir) {
     }
   }
 }
+
+/**
+ * Implements hook_twig_function().
+ */
+function es_helper_twig_function($functions) {
+  $functions['patternlab_path'] = new Twig_SimpleFunction('patternlab_path', 'es_helper_patternlab_path');
+  return $functions;
+}
+
+/**
+ * Return path to patternlab instance.
+ */
+function es_helper_patternlab_path() {
+  global $theme;
+  return base_path() . drupal_get_path('theme', $theme) . '/source';
+}
+


### PR DESCRIPTION
This will add the `patternlab_path` twig function. this will not collide with existing implementations in our utils_module. (Tested on ssc)